### PR TITLE
Fixing if condition bug!

### DIFF
--- a/driver-gekko.c
+++ b/driver-gekko.c
@@ -651,7 +651,7 @@ static void *compac_listen(void *object)
 					break;
 				case MINER_OPEN_CORE:
 					if ((info->rx[0] == 0x72 && info->rx[1] == 0x03 && info->rx[2] == 0xEA && info->rx[3] == 0x83) ||
-						(info->rx[0] == 0xE1 && info->rx[0] == 0x6B && info->rx[0] == 0xF8 && info->rx[0] == 0x09)) {
+						(info->rx[0] == 0xE1 && info->rx[1] == 0x6B && info->rx[2] == 0xF8 && info->rx[3] == 0x09)) {
 						//open core nonces = healthy chips.
 						info->zero_check++;
 					}


### PR DESCRIPTION
In `driver-gekko.c`, the right side of an `||` expression always evaluated to false because it was testing that the same byte is simultaneously equal to four different values, which is logically impossible without being `volatile` (and if even if it were `volatile` it would almost certainly still be a bug).

Instead, I believe the intention was to work like the left-hand expression, which tests four consecutive bytes. I've changed it to do that.

So I changed it *from* this

```code
case MINER_OPEN_CORE:
    if ((info->rx[0] == 0x72 && info->rx[1] == 0x03 && info->rx[2] == 0xEA && info->rx[3] == 0x83) ||
        (info->rx[0] == 0xE1 && info->rx[0] == 0x6B && info->rx[0] == 0xF8 && info->rx[0] == 0x09)) {
        //open core nonces = healthy chips.
        info->zero_check++;
    }
    break;
```

*to* this

```code
case MINER_OPEN_CORE:
    if ((info->rx[0] == 0x72 && info->rx[1] == 0x03 && info->rx[2] == 0xEA && info->rx[3] == 0x83) ||
        (info->rx[0] == 0xE1 && info->rx[1] == 0x6B && info->rx[2] == 0xF8 && info->rx[3] == 0x09)) {
        //open core nonces = healthy chips.
        info->zero_check++;
    }
    break;
```
